### PR TITLE
feat: Implement task claim feature with Kanban board

### DIFF
--- a/app/api/tasks/claim/route.ts
+++ b/app/api/tasks/claim/route.ts
@@ -1,0 +1,99 @@
+import { createClient } from "@/utils/supabase/server";
+import { NextResponse } from "next/server";
+
+// POST /api/tasks/claim - Claim a task
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    // Get current user
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { taskId } = body;
+
+    if (!taskId) {
+      return NextResponse.json(
+        { error: "Task ID is required" },
+        { status: 400 }
+      );
+    }
+
+    // Check if task exists and is not already claimed
+    const { data: existingTask, error: fetchError } = await supabase
+      .from("tasks")
+      .select("task_id, status, claimed_by")
+      .eq("task_id", taskId)
+      .single();
+
+    if (fetchError || !existingTask) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+
+    if (existingTask.claimed_by) {
+      return NextResponse.json(
+        { error: "Task is already claimed" },
+        { status: 400 }
+      );
+    }
+
+    if (existingTask.status !== "todo") {
+      return NextResponse.json(
+        { error: "Only tasks with 'todo' status can be claimed" },
+        { status: 400 }
+      );
+    }
+
+    // Claim the task - update status to 'assigned' and set claimed_by
+    const { data: updatedTask, error: updateError } = await supabase
+      .from("tasks")
+      .update({
+        claimed_by: user.id,
+        claimed_at: new Date().toISOString(),
+        status: "assigned",
+      })
+      .eq("task_id", taskId)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error("Error claiming task:", updateError);
+      return NextResponse.json(
+        { error: "Failed to claim task" },
+        { status: 500 }
+      );
+    }
+
+    // Get claimant name
+    const { data: customer } = await supabase
+      .from("customers")
+      .select("first_name, last_name")
+      .eq("id", user.id)
+      .single();
+
+    const claimantName = customer
+      ? [customer.first_name, customer.last_name].filter(Boolean).join(" ") ||
+        "Unknown"
+      : "Unknown";
+
+    return NextResponse.json({
+      task: {
+        ...updatedTask,
+        claimant_name: claimantName,
+      },
+      message: "Task claimed successfully",
+    });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,132 @@
+import { createClient } from "@/utils/supabase/server";
+import { NextResponse } from "next/server";
+
+// GET /api/tasks - Fetch all tasks with claimant information
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    // Get current user
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Fetch tasks with claimant details
+    const { data: tasks, error } = await supabase
+      .from("tasks")
+      .select(`
+        task_id,
+        title,
+        description,
+        status,
+        claimed_by,
+        claimed_at,
+        created_at,
+        updated_at
+      `)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      console.error("Error fetching tasks:", error);
+      return NextResponse.json(
+        { error: "Failed to fetch tasks" },
+        { status: 500 }
+      );
+    }
+
+    // Get claimant names for tasks that have been claimed
+    const claimedByIds = tasks
+      ?.filter((task) => task.claimed_by)
+      .map((task) => task.claimed_by) || [];
+
+    let claimantMap: Record<string, string> = {};
+
+    if (claimedByIds.length > 0) {
+      const { data: customers } = await supabase
+        .from("customers")
+        .select("id, first_name, last_name")
+        .in("id", claimedByIds);
+
+      if (customers) {
+        claimantMap = customers.reduce((acc, customer) => {
+          const name = [customer.first_name, customer.last_name]
+            .filter(Boolean)
+            .join(" ") || "Unknown";
+          acc[customer.id] = name;
+          return acc;
+        }, {} as Record<string, string>);
+      }
+    }
+
+    // Add claimant names to tasks
+    const tasksWithClaimants = tasks?.map((task) => ({
+      ...task,
+      claimant_name: task.claimed_by ? claimantMap[task.claimed_by] : null,
+    }));
+
+    return NextResponse.json({ tasks: tasksWithClaimants });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST /api/tasks - Create a new task
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    // Get current user
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { title, description } = body;
+
+    if (!title) {
+      return NextResponse.json(
+        { error: "Title is required" },
+        { status: 400 }
+      );
+    }
+
+    const { data: task, error } = await supabase
+      .from("tasks")
+      .insert({
+        title,
+        description: description || null,
+        status: "todo",
+        created_by: user.id,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error("Error creating task:", error);
+      return NextResponse.json(
+        { error: "Failed to create task" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ task }, { status: 201 });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { LayoutDashboard, User, ShoppingCart } from "lucide-react";
+import { LayoutDashboard, User, ShoppingCart, ClipboardList } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useState, useEffect } from "react";
 import { createClient } from "@/utils/supabase/client";
@@ -17,6 +17,7 @@ export default function DashboardLayout({
   const navigation = [
     { name: "Overview", href: "/dashboard", icon: LayoutDashboard },
     { name: "My Orders", href: "/dashboard/orders", icon: ShoppingCart },
+    { name: "Tasks", href: "/dashboard/tasks", icon: ClipboardList },
     { name: "Profile", href: "/dashboard/profile", icon: User },
   ];
 
@@ -70,8 +71,8 @@ export default function DashboardLayout({
                 key={item.name}
                 href={item.href}
                 className={`flex items-center gap-3 px-5 py-3 rounded-xl font-medium transition-all duration-200 group border border-transparent bg-transparent
-                  ${isActive ? "bg-[hsl(var(--status-success-bg))] text-[hsl(var(--status-success-text))] border-[hsl(var(--border))] shadow-md" : "text-[hsl(var(--text-secondary))] hover:bg-[hsl(var(--surface-hover))] hover:text-[hsl(var(--status-success-text))] hover:border-[hsl(var(--border))] hover:shadow-sm"}
-                  hover:scale-[1.03]`}
+                ${isActive ? "bg-[hsl(var(--status-success-bg))] text-[hsl(var(--status-success-text))] border-[hsl(var(--border))] shadow-md" : "text-[hsl(var(--text-secondary))] hover:bg-[hsl(var(--surface-hover))] hover:text-[hsl(var(--status-success-text))] hover:border-[hsl(var(--border))] hover:shadow-sm"}
+                hover:scale-[1.03]`}
               >
                 <item.icon
                   className={`w-5 h-5 ${isActive ? "text-[hsl(var(--status-success-text))]" : "text-[hsl(var(--text-muted))] group-hover:text-[hsl(var(--status-success-text))]"}`}

--- a/app/dashboard/tasks/page.tsx
+++ b/app/dashboard/tasks/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { createClient } from "@/utils/supabase/client";
+import { KanbanBoard, Task } from "@/components/tasks";
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import { ClipboardList, RefreshCw } from "lucide-react";
+
+export default function TasksPage() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Fetch current user
+  useEffect(() => {
+    async function fetchUser() {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      setCurrentUserId(user?.id || null);
+    }
+    fetchUser();
+  }, []);
+
+  // Fetch tasks
+  const fetchTasks = async () => {
+    try {
+      setError(null);
+      const response = await fetch("/api/tasks");
+      
+      if (!response.ok) {
+        if (response.status === 401) {
+          setError("Please log in to view tasks");
+          return;
+        }
+        throw new Error("Failed to fetch tasks");
+      }
+
+      const data = await response.json();
+      setTasks(data.tasks || []);
+    } catch (err) {
+      console.error("Error fetching tasks:", err);
+      setError("Failed to load tasks. Please try again.");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTasks();
+  }, []);
+
+  // Handle claiming a task
+  const handleClaimTask = async (taskId: number) => {
+    try {
+      const response = await fetch("/api/tasks/claim", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ taskId }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to claim task");
+      }
+
+      const data = await response.json();
+      
+      // Update the task in local state
+      setTasks((prevTasks) =>
+        prevTasks.map((task) =>
+          task.task_id === taskId ? data.task : task
+        )
+      );
+    } catch (err) {
+      console.error("Error claiming task:", err);
+      alert(err instanceof Error ? err.message : "Failed to claim task");
+    }
+  };
+
+  // Handle refresh
+  const handleRefresh = () => {
+    setRefreshing(true);
+    fetchTasks();
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex flex-col items-center">
+          <LoadingSpinner size="lg" />
+          <p className="mt-4 text-text-secondary">Loading tasks...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <ClipboardList className="w-12 h-12 text-text-muted mx-auto mb-4" />
+          <p className="text-status-error-text mb-4">{error}</p>
+          <button
+            onClick={handleRefresh}
+            className="px-4 py-2 bg-btn-primary text-btn-primary-text rounded-lg hover:bg-btn-primary-hover transition-colors"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-text-primary">Tasks</h1>
+          <p className="text-text-secondary mt-1">
+            View and claim tasks from the board
+          </p>
+        </div>
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className={`inline-flex items-center px-4 py-2 rounded-lg transition-colors ${
+            refreshing
+              ? "bg-btn-disabled text-btn-disabled-text cursor-not-allowed"
+              : "bg-btn-secondary text-text-primary hover:bg-btn-secondary-hover"
+          }`}
+        >
+          <RefreshCw
+            className={`w-4 h-4 mr-2 ${refreshing ? "animate-spin" : ""}`}
+          />
+          Refresh
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-background rounded-xl shadow-sm border border-border p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-text-secondary">To Do</p>
+              <p className="text-2xl font-bold text-text-primary">
+                {tasks.filter((t) => t.status === "todo").length}
+              </p>
+            </div>
+            <div className="p-3 bg-status-info-bg rounded-lg">
+              <ClipboardList className="w-5 h-5 text-status-info-text" />
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-background rounded-xl shadow-sm border border-border p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-text-secondary">Assigned</p>
+              <p className="text-2xl font-bold text-text-primary">
+                {tasks.filter((t) => t.status === "assigned").length}
+              </p>
+            </div>
+            <div className="p-3 bg-status-warning-bg rounded-lg">
+              <ClipboardList className="w-5 h-5 text-status-warning-text" />
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-background rounded-xl shadow-sm border border-border p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-text-secondary">Done</p>
+              <p className="text-2xl font-bold text-text-primary">
+                {tasks.filter((t) => t.status === "done").length}
+              </p>
+            </div>
+            <div className="p-3 bg-status-success-bg rounded-lg">
+              <ClipboardList className="w-5 h-5 text-status-success-text" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Kanban Board */}
+      <KanbanBoard
+        tasks={tasks}
+        currentUserId={currentUserId}
+        onClaimTask={handleClaimTask}
+        isLoading={refreshing}
+      />
+    </div>
+  );
+}

--- a/components/tasks/KanbanBoard.tsx
+++ b/components/tasks/KanbanBoard.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Task } from "./TaskCard";
+import TaskCard from "./TaskCard";
+import { ClipboardList, UserCheck, CheckCircle2 } from "lucide-react";
+
+interface KanbanBoardProps {
+  tasks: Task[];
+  currentUserId: string | null;
+  onClaimTask: (taskId: number) => Promise<void>;
+  isLoading?: boolean;
+}
+
+interface ColumnProps {
+  title: string;
+  icon: React.ReactNode;
+  tasks: Task[];
+  currentUserId: string | null;
+  onClaimTask: (taskId: number) => Promise<void>;
+  isLoading?: boolean;
+  bgColor: string;
+  borderColor: string;
+}
+
+function KanbanColumn({
+  title,
+  icon,
+  tasks,
+  currentUserId,
+  onClaimTask,
+  isLoading,
+  bgColor,
+  borderColor,
+}: ColumnProps) {
+  return (
+    <div className={`flex flex-col rounded-xl ${bgColor} border ${borderColor} min-h-[500px]`}>
+      {/* Column Header */}
+      <div className="p-4 border-b border-border">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {icon}
+            <h2 className="font-semibold text-text-primary">{title}</h2>
+          </div>
+          <span className="px-2 py-1 text-xs font-medium rounded-full bg-surface text-text-secondary">
+            {tasks.length}
+          </span>
+        </div>
+      </div>
+
+      {/* Column Content */}
+      <div className="flex-1 p-3 space-y-3 overflow-y-auto">
+        {tasks.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <div className="w-12 h-12 rounded-full bg-surface flex items-center justify-center mb-3">
+              <ClipboardList className="w-6 h-6 text-text-muted" />
+            </div>
+            <p className="text-sm text-text-muted">No tasks here</p>
+          </div>
+        ) : (
+          tasks.map((task) => (
+            <TaskCard
+              key={task.task_id}
+              task={task}
+              currentUserId={currentUserId}
+              onClaim={onClaimTask}
+              isLoading={isLoading}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function KanbanBoard({
+  tasks,
+  currentUserId,
+  onClaimTask,
+  isLoading = false,
+}: KanbanBoardProps) {
+  // Separate tasks by status
+  const todoTasks = tasks.filter((task) => task.status === "todo");
+  const assignedTasks = tasks.filter((task) => task.status === "assigned");
+  const doneTasks = tasks.filter((task) => task.status === "done");
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {/* To Do Column */}
+      <KanbanColumn
+        title="To Do"
+        icon={<ClipboardList className="w-5 h-5 text-status-info-text" />}
+        tasks={todoTasks}
+        currentUserId={currentUserId}
+        onClaimTask={onClaimTask}
+        isLoading={isLoading}
+        bgColor="bg-status-info-bg/30"
+        borderColor="border-status-info-bg"
+      />
+
+      {/* Assigned Column */}
+      <KanbanColumn
+        title="Assigned"
+        icon={<UserCheck className="w-5 h-5 text-status-warning-text" />}
+        tasks={assignedTasks}
+        currentUserId={currentUserId}
+        onClaimTask={onClaimTask}
+        isLoading={isLoading}
+        bgColor="bg-status-warning-bg/30"
+        borderColor="border-status-warning-bg"
+      />
+
+      {/* Done Column */}
+      <KanbanColumn
+        title="Done"
+        icon={<CheckCircle2 className="w-5 h-5 text-status-success-text" />}
+        tasks={doneTasks}
+        currentUserId={currentUserId}
+        onClaimTask={onClaimTask}
+        isLoading={isLoading}
+        bgColor="bg-status-success-bg/30"
+        borderColor="border-status-success-bg"
+      />
+    </div>
+  );
+}

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { User, Clock, CheckCircle } from "lucide-react";
+
+export interface Task {
+  task_id: number;
+  title: string;
+  description: string | null;
+  status: "todo" | "assigned" | "done";
+  claimed_by: string | null;
+  claimed_at: string | null;
+  claimant_name?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TaskCardProps {
+  task: Task;
+  currentUserId: string | null;
+  onClaim: (taskId: number) => Promise<void>;
+  isLoading?: boolean;
+}
+
+export default function TaskCard({
+  task,
+  currentUserId,
+  onClaim,
+  isLoading = false,
+}: TaskCardProps) {
+  const [claiming, setClaiming] = useState(false);
+
+  const handleClaim = async () => {
+    if (claiming || isLoading) return;
+    setClaiming(true);
+    try {
+      await onClaim(task.task_id);
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  const isClaimedByCurrentUser = task.claimed_by === currentUserId;
+  const canClaim = task.status === "todo" && !task.claimed_by && currentUserId;
+
+  const getStatusBadge = () => {
+    switch (task.status) {
+      case "todo":
+        return (
+          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-status-info-bg text-status-info-text">
+            <Clock className="w-3 h-3 mr-1" />
+            To Do
+          </span>
+        );
+      case "assigned":
+        return (
+          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-status-warning-bg text-status-warning-text">
+            <User className="w-3 h-3 mr-1" />
+            Assigned
+          </span>
+        );
+      case "done":
+        return (
+          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-status-success-bg text-status-success-text">
+            <CheckCircle className="w-3 h-3 mr-1" />
+            Done
+          </span>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="bg-background rounded-xl shadow-sm border border-border p-4 hover:shadow-md transition-shadow duration-200">
+      {/* Header with status badge */}
+      <div className="flex items-start justify-between mb-3">
+        <h3 className="font-semibold text-text-primary text-sm leading-tight flex-1 mr-2">
+          {task.title}
+        </h3>
+        {getStatusBadge()}
+      </div>
+
+      {/* Description */}
+      {task.description && (
+        <p className="text-text-secondary text-xs mb-4 line-clamp-2">
+          {task.description}
+        </p>
+      )}
+
+      {/* Claimant info */}
+      {task.claimed_by && task.claimant_name && (
+        <div className="flex items-center mb-3 p-2 bg-surface-hover rounded-lg">
+          <div className="w-6 h-6 rounded-full bg-status-success-bg flex items-center justify-center mr-2">
+            <User className="w-3 h-3 text-status-success-text" />
+          </div>
+          <div className="flex-1">
+            <p className="text-xs font-medium text-text-primary">
+              {isClaimedByCurrentUser ? "Claimed by you" : `Claimed by ${task.claimant_name}`}
+            </p>
+            {task.claimed_at && (
+              <p className="text-xs text-text-muted">
+                {new Date(task.claimed_at).toLocaleDateString()}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Claim button */}
+      {canClaim && (
+        <button
+          onClick={handleClaim}
+          disabled={claiming || isLoading}
+          className={`w-full py-2 px-4 rounded-lg text-sm font-medium transition-all duration-200 ${
+            claiming || isLoading
+              ? "bg-btn-disabled text-btn-disabled-text cursor-not-allowed"
+              : "bg-btn-primary text-btn-primary-text hover:bg-btn-primary-hover active:scale-[0.98]"
+          }`}
+        >
+          {claiming ? "Claiming..." : "Claim Task"}
+        </button>
+      )}
+
+      {/* Created date */}
+      <div className="mt-3 pt-3 border-t border-border">
+        <p className="text-xs text-text-muted">
+          Created {new Date(task.created_at).toLocaleDateString()}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/tasks/index.ts
+++ b/components/tasks/index.ts
@@ -1,0 +1,3 @@
+export { default as TaskCard } from "./TaskCard";
+export { default as KanbanBoard } from "./KanbanBoard";
+export type { Task } from "./TaskCard";

--- a/tasks_schema.sql
+++ b/tasks_schema.sql
@@ -1,0 +1,54 @@
+-- Database Schema for Tasks Feature
+-- This adds task management with claim functionality
+
+-- Create tasks table
+CREATE TABLE IF NOT EXISTS tasks (
+  task_id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT DEFAULT 'todo' CHECK (status IN ('todo', 'assigned', 'done')),
+  claimed_by UUID REFERENCES customers(id) ON DELETE SET NULL,
+  claimed_at TIMESTAMP WITH TIME ZONE,
+  created_by UUID REFERENCES customers(id) ON DELETE SET NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Enable Row Level Security
+ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;
+
+-- Create policies for tasks table
+-- All authenticated users can view all tasks
+CREATE POLICY "Authenticated users can view all tasks" ON tasks
+  FOR SELECT USING (auth.uid() IS NOT NULL);
+
+-- Authenticated users can insert tasks
+CREATE POLICY "Authenticated users can insert tasks" ON tasks
+  FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+
+-- Users can update tasks (for claiming and status changes)
+CREATE POLICY "Authenticated users can update tasks" ON tasks
+  FOR UPDATE USING (auth.uid() IS NOT NULL);
+
+-- Create function to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_tasks_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger for updated_at
+DROP TRIGGER IF EXISTS tasks_updated_at ON tasks;
+CREATE TRIGGER tasks_updated_at
+  BEFORE UPDATE ON tasks
+  FOR EACH ROW EXECUTE FUNCTION update_tasks_updated_at();
+
+-- Insert sample tasks for testing
+INSERT INTO tasks (title, description, status) VALUES
+('Fix homepage hero section', 'Update the hero section with new branding images and improve responsive design', 'todo'),
+('Add product filtering', 'Implement filter functionality for bikes by price, type, and availability', 'todo'),
+('Update checkout flow', 'Improve the checkout process with better error handling and validation', 'todo'),
+('Write API documentation', 'Document all API endpoints for the development team', 'todo'),
+('Optimize image loading', 'Implement lazy loading and image optimization for better performance', 'todo');


### PR DESCRIPTION
- Add tasks database schema with SQL migration file
- Create TaskCard component with claim button functionality
- Create KanbanBoard component with Todo, Assigned, Done columns
- Add API routes for fetching tasks and claiming tasks
- Add Tasks page to dashboard at /dashboard/tasks
- Add Tasks navigation link to dashboard sidebar

When a member clicks the 'Claim' button on a task card:
- The task status changes from 'todo' to 'assigned'
- The card moves to the 'Assigned' column
- The claimant's name is displayed on the card